### PR TITLE
Beautify logo style

### DIFF
--- a/public/src/css/common.css
+++ b/public/src/css/common.css
@@ -8054,9 +8054,6 @@ a.v_highlight_more {
     h2 {
         font-size: 20px;
     }
-    .navbar-default .navbar-brand {
-        padding: 8px 0;
-    }
     .insight {
         font-size: 26px;
     }

--- a/public/views/includes/header.html
+++ b/public/views/includes/header.html
@@ -9,7 +9,7 @@
       </button>
       <div>
         <a class="insight navbar-brand" href=".">
-        <img src="../img/FiroLogoWhite.svg" style="width: 150px; height: 66px;" alt="firo_logo">
+        <img src="../img/FiroLogoWhite.svg" style="width: 150px; height: 64px;" alt="firo_logo">
       </a>
       </div>
     </div>


### PR DESCRIPTION
The logo is not centered in mobile mode.

The logo height is 2px higher than the header.

I adjusted it.

# Before

![image](https://user-images.githubusercontent.com/8684548/108586446-9efc9800-7389-11eb-9937-e399d0437882.png)

# After

![image](https://user-images.githubusercontent.com/8684548/108586442-973cf380-7389-11eb-96cb-5e237b266e11.png)
